### PR TITLE
Enum Flags

### DIFF
--- a/cpp/Enum.h
+++ b/cpp/Enum.h
@@ -1,0 +1,210 @@
+//
+//  Copyright (c) 2014-2017 Philipp Paulweber
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                https://github.com/ppaulweber/libstdhl
+//
+//  This file is part of libstdhl.
+//
+//  libstdhl is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libstdhl is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libstdhl. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef _LIB_STDHL_CPP_ENUM_H_
+#define _LIB_STDHL_CPP_ENUM_H_
+
+#include <type_traits>
+
+/**
+   @brief    TODO
+
+   TODO
+*/
+
+namespace libstdhl
+{
+    /**
+     * @extends Stdhl
+     */
+    namespace Enum
+    {
+        /**
+         * @brief Provides a type-safe way of storing enum value combinations.
+         */
+        template< typename Enum >
+        class Flags
+        {
+            using UnderlyingType = typename std::underlying_type< Enum >::type;
+
+          public:
+            static_assert( std::is_enum< Enum >::value, "Template parameter must be an enum" );
+
+            /**
+             * No flags will be set initially.
+             */
+            Flags( void )
+            : m_flags( 0 )
+            {
+            }
+
+            /**
+             * Sets the flag \a e on initialization, all other flags will be
+             * cleared.
+             */
+            Flags( const Enum e )
+            : m_flags( asBitValue( e ) )
+            {
+            }
+
+            /**
+             * Sets the flag \a e if it's not already set.
+             */
+            void set( Enum e )
+            {
+                m_flags |= asBitValue( e );
+            }
+
+            /**
+             * Clears the flag \a e if it's set.
+             */
+            void unset( Enum e )
+            {
+                m_flags &= ~asBitValue( e );
+            }
+
+            /**
+             * Sets the flag \a e if it's not already set, or clears it if it's
+             * set.
+             */
+            void flip( Enum e )
+            {
+                m_flags ^= asBitValue( e );
+            }
+
+            /**
+             * Checks whether the flag \a e is set.
+             *
+             * @return True if the flag is set, false otherwise.
+             */
+            bool isSet( Enum e ) const
+            {
+                return (m_flags & asBitValue( e )) != 0;
+            }
+
+            /**
+             * Clears all flags.
+             */
+            void clear( void )
+            {
+                m_flags = 0;
+            }
+
+            /**
+             * Checks whether one or more flags are set.
+             *
+             * @return True if no flag is set, false otherwise.
+             */
+            bool empty( void ) const
+            {
+                return m_flags == 0;
+            }
+
+            /**
+             * Checks whether the flag \a e is set.
+             *
+             * @return True if the flag is set, false otherwise.
+             */
+            bool operator&( Enum e ) const
+            {
+                return isSet( e );
+            }
+
+            /**
+             * Sets the flag \a e if it's not already set.
+             */
+            Flags& operator|=( Enum e )
+            {
+                set( e );
+                return *this;
+            }
+
+            /**
+             * Sets the flag \a e in \a flags if it's not already set.
+             */
+            friend Flags operator|( Flags flags, Enum e )
+            {
+                flags.set( e );
+                return flags;
+            }
+
+            /**
+             * Combines \a lhs and \a rhs
+             */
+            friend Flags operator|( Flags lhs, Flags rhs )
+            {
+                lhs.m_flags |= rhs.m_flags;
+                return lhs;
+            }
+
+            /**
+             * Sets the flag \a e if it's not already set, or clears it if it's
+             * set.
+             */
+            Flags& operator^=( Enum e )
+            {
+                flip( e );
+                return *this;
+            }
+
+            /**
+             * Sets the flag \a e in \a flags if it's not already set, or
+             * clears it in \a flags if it's set.
+             */
+            friend Flags operator^( Flags flags, Enum e )
+            {
+                flags.flip( e );
+                return flags;
+            }
+
+          private:
+            static constexpr UnderlyingType asBitValue( Enum e )
+            {
+                return 2 << static_cast< UnderlyingType >( e );
+            }
+
+          private:
+            UnderlyingType m_flags;
+        };
+    }
+}
+
+template< typename T >
+typename std::enable_if< std::is_enum< T >::value, libstdhl::Enum::Flags< T > >::type
+operator|( T lhs, T rhs )
+{
+    return libstdhl::Enum::Flags< T >( lhs ) | libstdhl::Enum::Flags< T >( rhs );
+}
+
+#endif // _LIB_STDHL_CPP_ENUM_H_
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/cpp/Enum.h
+++ b/cpp/Enum.h
@@ -64,7 +64,7 @@ namespace libstdhl
              * Sets the flag \a e on initialization, all other flags will be
              * cleared.
              */
-            Flags( const Enum e )
+            Flags( Enum e )
             : m_flags( asBitValue( e ) )
             {
             }

--- a/cpp/Enum.h
+++ b/cpp/Enum.h
@@ -180,9 +180,11 @@ namespace libstdhl
             }
 
           private:
-            static constexpr UnderlyingType asBitValue( Enum e )
+            static UnderlyingType asBitValue( Enum e )
             {
-                return 2 << static_cast< UnderlyingType >( e );
+                assert( static_cast< UnderlyingType >( e )
+                        < ( sizeof( UnderlyingType ) * 8 ) );
+                return 1 << static_cast< UnderlyingType >( e );
             }
 
           private:

--- a/cpp/Enum.h
+++ b/cpp/Enum.h
@@ -43,13 +43,14 @@ namespace libstdhl
         /**
          * @brief Provides a type-safe way of storing enum value combinations.
          */
-        template< typename Enum >
+        template < typename Enum >
         class Flags
         {
             using UnderlyingType = typename std::underlying_type< Enum >::type;
 
           public:
-            static_assert( std::is_enum< Enum >::value, "Template parameter must be an enum" );
+            static_assert( std::is_enum< Enum >::value,
+                "Template parameter must be an enum" );
 
             /**
              * No flags will be set initially.
@@ -100,7 +101,7 @@ namespace libstdhl
              */
             bool isSet( Enum e ) const
             {
-                return (m_flags & asBitValue( e )) != 0;
+                return ( m_flags & asBitValue( e ) ) != 0;
             }
 
             /**
@@ -190,11 +191,13 @@ namespace libstdhl
     }
 }
 
-template< typename T >
-typename std::enable_if< std::is_enum< T >::value, libstdhl::Enum::Flags< T > >::type
+template < typename T >
+typename std::enable_if< std::is_enum< T >::value,
+    libstdhl::Enum::Flags< T > >::type
 operator|( T lhs, T rhs )
 {
-    return libstdhl::Enum::Flags< T >( lhs ) | libstdhl::Enum::Flags< T >( rhs );
+    return libstdhl::Enum::Flags< T >( lhs )
+           | libstdhl::Enum::Flags< T >( rhs );
 }
 
 #endif // _LIB_STDHL_CPP_ENUM_H_

--- a/libstdhl.h
+++ b/libstdhl.h
@@ -46,6 +46,7 @@
 #include "cpp/Args.h"
 #include "cpp/Binding.h"
 #include "cpp/Default.h"
+#include "cpp/Enum.h"
 #include "cpp/File.h"
 #include "cpp/Labeling.h"
 #include "cpp/List.h"

--- a/uts/cpp/Enum.cpp
+++ b/uts/cpp/Enum.cpp
@@ -1,0 +1,220 @@
+//
+//  Copyright (c) 2014-2017 Philipp Paulweber
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                https://github.com/ppaulweber/libstdhl
+//
+//  This file is part of libstdhl.
+//
+//  libstdhl is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libstdhl is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libstdhl. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "gtest/gtest.h"
+
+#include "libstdhl.h"
+
+using namespace libstdhl;
+
+enum class Color
+{
+    Red,
+    Green,
+    Blue
+};
+
+using Colors = Enum::Flags< Color >;
+
+TEST( libstdhl_cpp_Enum_Flags, initially_no_color_should_be_set )
+{
+    // WHEN
+    Colors colors;
+
+    // THEN
+    EXPECT_TRUE( colors.empty() );
+    EXPECT_FALSE( colors.isSet( Color::Red ) );
+    EXPECT_FALSE( colors.isSet( Color::Green ) );
+    EXPECT_FALSE( colors.isSet( Color::Blue ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, set_should_persist )
+{
+    // WHEN
+    Colors colors;
+    colors.set( Color::Green );
+
+    // THEN
+    EXPECT_TRUE( colors.isSet( Color::Green ) );
+    EXPECT_TRUE( colors & Color::Green );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, or_assign_operator_set_should_persist )
+{
+    // WHEN
+    Colors colors;
+    colors |= Color::Green;
+
+    // THEN
+    EXPECT_TRUE( colors.isSet( Color::Green ) );
+    EXPECT_TRUE( colors & Color::Green );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, or_operator_set_should_persist )
+{
+    // WHEN
+    Colors colors;
+    colors = colors | Color::Green;
+
+    // THEN
+    EXPECT_TRUE( colors.isSet( Color::Green ) );
+    EXPECT_TRUE( colors & Color::Green );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, empty_should_be_false_if_some_value_is_set )
+{
+    // WHEN
+    Colors colors;
+    colors.set( Color::Green );
+
+    // THEN
+    EXPECT_FALSE( colors.empty() );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, set_should_use_one_bit_for_each_enum_value )
+{
+    // WHEN
+    Colors colors;
+    colors.set( Color::Green );
+    colors.set( Color::Blue );
+
+    // THEN
+    EXPECT_FALSE( colors.isSet( Color::Red ) );
+    EXPECT_TRUE( colors.isSet( Color::Green ) );
+    EXPECT_TRUE( colors.isSet( Color::Blue ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, unset_should_persist )
+{
+    // PREPARE
+    Colors colors;
+    colors.set( Color::Green );
+    EXPECT_TRUE( colors.isSet( Color::Green ) );
+
+    // WHEN
+    colors.unset( Color::Green );
+
+    // THEN
+    EXPECT_FALSE( colors.isSet( Color::Green ) );
+    EXPECT_FALSE( colors & Color::Green );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, flip_should_set_if_currently_unset )
+{
+    // WHEN
+    Colors colors;
+    colors.flip( Color::Red );
+
+    // THEN
+    EXPECT_TRUE( colors.isSet( Color::Red ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, caret_assign_operator_should_set_if_currently_unset )
+{
+    // WHEN
+    Colors colors;
+    colors ^= Color::Red;
+
+    // THEN
+    EXPECT_TRUE( colors.isSet( Color::Red ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, caret_operator_should_set_if_currently_unset )
+{
+    // WHEN
+    Colors colors;
+    colors = colors ^ Color::Red;
+
+    // THEN
+    EXPECT_TRUE( colors.isSet( Color::Red ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, flip_should_unset_if_currently_set )
+{
+    // PREPARE
+    Colors colors;
+    colors.set( Color::Red );
+    EXPECT_TRUE( colors.isSet( Color::Red ) );
+
+    // WHEN
+    colors.flip( Color::Red );
+
+    // THEN
+    EXPECT_FALSE( colors.isSet( Color::Red ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, caret_assign_operator_flip_should_unset_if_currently_set )
+{
+    // PREPARE
+    Colors colors;
+    colors.set( Color::Red );
+    EXPECT_TRUE( colors.isSet( Color::Red ) );
+
+    // WHEN
+    colors ^= Color::Red;
+
+    // THEN
+    EXPECT_FALSE( colors.isSet( Color::Red ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, caret_operator_flip_should_unset_if_currently_set )
+{
+    // PREPARE
+    Colors colors;
+    colors.set( Color::Red );
+    EXPECT_TRUE( colors.isSet( Color::Red ) );
+
+    // WHEN
+    colors = colors ^ Color::Red;
+
+    // THEN
+    EXPECT_FALSE( colors.isSet( Color::Red ) );
+}
+
+TEST( libstdhl_cpp_Enum_Flags, or_operator_merge_should_persist )
+{
+    // PREPARE
+    Colors colors1;
+    colors1.set( Color::Red );
+
+    Colors colors2;
+    colors2.set( Color::Blue );
+
+    // WHEN
+    const Colors mergedColors = colors1 | colors2;
+
+    // THEN
+    EXPECT_TRUE( mergedColors.isSet( Color::Red ) );
+    EXPECT_TRUE( mergedColors.isSet( Color::Blue ) );
+}
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/uts/cpp/Enum.cpp
+++ b/uts/cpp/Enum.cpp
@@ -130,7 +130,8 @@ TEST( libstdhl_cpp_Enum_Flags, flip_should_set_if_currently_unset )
     EXPECT_TRUE( colors.isSet( Color::Red ) );
 }
 
-TEST( libstdhl_cpp_Enum_Flags, caret_assign_operator_should_set_if_currently_unset )
+TEST( libstdhl_cpp_Enum_Flags,
+    caret_assign_operator_should_set_if_currently_unset )
 {
     // WHEN
     Colors colors;
@@ -164,7 +165,8 @@ TEST( libstdhl_cpp_Enum_Flags, flip_should_unset_if_currently_set )
     EXPECT_FALSE( colors.isSet( Color::Red ) );
 }
 
-TEST( libstdhl_cpp_Enum_Flags, caret_assign_operator_flip_should_unset_if_currently_set )
+TEST( libstdhl_cpp_Enum_Flags,
+    caret_assign_operator_flip_should_unset_if_currently_set )
 {
     // PREPARE
     Colors colors;
@@ -178,7 +180,8 @@ TEST( libstdhl_cpp_Enum_Flags, caret_assign_operator_flip_should_unset_if_curren
     EXPECT_FALSE( colors.isSet( Color::Red ) );
 }
 
-TEST( libstdhl_cpp_Enum_Flags, caret_operator_flip_should_unset_if_currently_set )
+TEST(
+    libstdhl_cpp_Enum_Flags, caret_operator_flip_should_unset_if_currently_set )
 {
     // PREPARE
     Colors colors;


### PR DESCRIPTION
* Added a new Enum::Flags class which provides a type-safe way of storing
  enum value combinations.
* This is especially useful when using enum classes.
* Example:
~~~
enum class Color
{
    Red,
    Green,
    Blue
};

using Colors = Enum::Flags< Color >;

Colors c;
c.set( Color::Red );
if( c.isSet( Color::Red )) ...
~~~
* Provides bitwise | and & as well:
~~~
if( c & Color::Red ) ...
c |= Color::Red;
~~~